### PR TITLE
Convert package name to nvidia-imageinary

### DIFF
--- a/.github/workflows/pushtest.yml
+++ b/.github/workflows/pushtest.yml
@@ -33,24 +33,24 @@ jobs:
     - name: Install the built wheel and test usage (UNIX)
       if: matrix.operating-system == 'ubuntu-latest' || matrix.operating-system == 'macOS-latest'
       run: |
-        pip install --ignore-installed dist/imageinary-*-py3-none-any.whl
+        pip install --ignore-installed dist/nvidia_imageinary-*-py3-none-any.whl
         imagine --help
     - name: Install the built wheel and test usage (Windows)
       if: matrix.operating-system == 'windows-latest' || matrix.operating-system == 'windows-2016'
       run: |
-        pip install --ignore-installed --find-links=dist imageinary
+        pip install --ignore-installed --find-links=dist nvidia-imageinary
         imagine --help
     - name: Install the built wheel with all dependencies (UNIX)
       if: matrix.operating-system == 'ubuntu-latest' || matrix.operating-system == 'macOS-latest'
       run: |
-        pip install imageinary['all']
+        pip install nvidia-imageinary['all']
         imagine --help
         pip freeze | grep "tensorflow"
         pip freeze | grep "mxnet"
     - name: Install the built wheel with all dependencies (Windows)
       if: matrix.operating-system == 'windows-latest' || matrix.operating-system == 'windows-2016'
       run: |
-        pip install imageinary['all']
+        pip install nvidia-imageinary['all']
         imagine --help
         pip freeze | grep "tensorflow"
         pip freeze | grep "mxnet"
@@ -85,24 +85,24 @@ jobs:
     - name: Install the built wheel and test usage (UNIX)
       if: matrix.operating-system == 'ubuntu-latest' || matrix.operating-system == 'macOS-latest'
       run: |
-        pip install --ignore-installed dist/imageinary-*-py3-none-any.whl
+        pip install --ignore-installed dist/nvidia_imageinary-*-py3-none-any.whl
         imagine --help
     - name: Install the built wheel and test usage (Windows)
       if: matrix.operating-system == 'windows-latest' || matrix.operating-system == 'windows-2016'
       run: |
-        pip install --ignore-installed --find-links=dist imageinary
+        pip install --ignore-installed --find-links=dist nvidia-imageinary
         imagine --help
     - name: Install the built wheel with all dependencies (UNIX)
       if: matrix.operating-system == 'ubuntu-latest' || matrix.operating-system == 'macOS-latest'
       run: |
-        pip install tensorflow==1.14.0 imageinary['all']
+        pip install tensorflow==1.14.0 nvidia-imageinary['all']
         imagine --help
         pip freeze | grep "tensorflow"
         pip freeze | grep "mxnet"
     - name: Install the built wheel with all dependencies (Windows)
       if: matrix.operating-system == 'windows-latest' || matrix.operating-system == 'windows-2016'
       run: |
-        pip install tensorflow==1.14.0 imageinary['all']
+        pip install tensorflow==1.14.0 nvidia-imageinary['all']
         imagine --help
         pip freeze | grep "tensorflow"
         pip freeze | grep "mxnet"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ can be installed via `pip`.
 
 ```bash
 $ ls dist/
-imageinary-1.0.0-py3-none-any.whl imageinary-1.0.0.tar.gz
+nvidia-imageinary-1.0.1-py3-none-any.whl nvidia-imageinary-1.0.1.tar.gz
 ```
 
 ## Installing
@@ -76,7 +76,7 @@ The minimal install supports standard image types, such as JPG, PNG, and BMP
 and only installs the dependencies necessary for those tools.
 
 ```bash
-pip install imageinary
+pip install nvidia-imageinary
 ```
 
 ### TFRecord Support
@@ -85,7 +85,7 @@ needs to be included as a dependency. This can be done by running the following
 which installs TensorFlow alongside all other dependencies:
 
 ```bash
-pip install imageinary['tfrecord']
+pip install nvidia-imageinary['tfrecord']
 ```
 
 ### RecordIO Support
@@ -93,7 +93,7 @@ RecordIO files are supported using MXNet, which can be included as a dependency
 using the following:
 
 ```bash
-pip install imageinary['mxnet']
+pip install nvidia-imageinary['mxnet']
 ```
 
 ### Complete Install
@@ -102,7 +102,7 @@ TFRecords, and RecordIO files without installing extra packages later. Run the
 following to install all dependencies:
 
 ```bash
-pip install imageinary['all']
+pip install nvidia-imageinary['all']
 ```
 
 ## Running

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras = {
 extras['all'] = [item for group in extras.values() for item in group]
 
 setup(
-    name='imageinary',
+    name='nvidia-imageinary',
     version=version,
     description='''A reproducible mechanism which is used to generate large
 image datasets at various resolutions. The tool supports multiple image types,


### PR DESCRIPTION
In preparation for releasing on `nvidia-pyindex`, the package name needs to be updated to follow the naming convention of that index.

Closes #9 

Signed-Off-By: Robert Clark <roclark@nvidia.com>