### PR TITLE
Replace click with argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ requested output format and saved to the specified location.
   * MXNet
   * Pillow
   * Numpy
-  * Click
 
 ## Installation
 The application is available on `nvidia-pyindex` and can be downloaded and

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ attrs==20.2.0
 cachetools==4.1.0
 certifi==2020.4.5.1
 chardet==3.0.4
-click==7.1.2
 coverage==5.3
 gast==0.3.3
 google-auth==1.14.3

--- a/requirements.txt.tf1
+++ b/requirements.txt.tf1
@@ -3,7 +3,6 @@ astor==0.8.1
 attrs==20.2.0
 certifi==2020.4.5.2
 chardet==3.0.4
-click==7.1.2
 coverage==5.3
 gast==0.3.3
 google-pasta==0.2.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ including JPEGs, PNGs, BMPs, RecordIO, and TFRecord files''',
         'console_scripts': ['imagine=imagine.imagine:main']
     },
     install_requires=[
-        'click >= 7.1.2',
         'numpy >= 1.18.0',
         'Pillow >= 7.1.2'
     ],

--- a/tests/functional/test_jpg_creation.py
+++ b/tests/functional/test_jpg_creation.py
@@ -14,9 +14,8 @@
 import pytest
 import re
 import os
-from click.testing import CliRunner
 from glob import glob
-from imagine.imagine import main
+from imagine.imagine import create_images
 from PIL import Image
 
 
@@ -24,7 +23,6 @@ class TestJPGCreation:
     @pytest.fixture(autouse=True)
     def setup(self, tmpdir):
         self.tmpdir = tmpdir.mkdir('jpg_files')
-        self.runner = CliRunner()
 
     def teardown_method(self):
         for image in glob(f'{str(self.tmpdir)}/*'):
@@ -32,13 +30,16 @@ class TestJPGCreation:
         os.rmdir(str(self.tmpdir))
 
     def test_creating_one_hundred_images(self):
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 1920,
-                                  '--height', 1080,
-                                  '--count', 100,
-                                  '--image_format', 'jpg'])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            1920,
+            1080,
+            100,
+            'jpg',
+            0,
+            False
+        )
 
         images = glob(f'{str(self.tmpdir)}/*')
 
@@ -49,13 +50,16 @@ class TestJPGCreation:
                 assert im.size == (1920, 1080)
 
     def test_creating_one_hundred_4K_images(self):
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 3840,
-                                  '--height', 2160,
-                                  '--count', 100,
-                                  '--image_format', 'jpg'])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            3840,
+            2160,
+            100,
+            'jpg',
+            0,
+            False
+        )
 
         images = glob(f'{str(self.tmpdir)}/*')
 

--- a/tests/functional/test_png_creation.py
+++ b/tests/functional/test_png_creation.py
@@ -14,9 +14,8 @@
 import pytest
 import re
 import os
-from click.testing import CliRunner
 from glob import glob
-from imagine.imagine import main
+from imagine.imagine import create_images
 from PIL import Image
 
 
@@ -24,7 +23,6 @@ class TestPNGCreation:
     @pytest.fixture(autouse=True)
     def setup(self, tmpdir):
         self.tmpdir = tmpdir.mkdir('png_files')
-        self.runner = CliRunner()
 
     def teardown_method(self):
         for image in glob(f'{str(self.tmpdir)}/*'):
@@ -32,13 +30,16 @@ class TestPNGCreation:
         os.rmdir(str(self.tmpdir))
 
     def test_creating_one_hundred_images(self):
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 1920,
-                                  '--height', 1080,
-                                  '--count', 100,
-                                  '--image_format', 'png'])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            1920,
+            1080,
+            100,
+            'png',
+            0,
+            False
+        )
 
         images = glob(f'{str(self.tmpdir)}/*')
 
@@ -49,13 +50,16 @@ class TestPNGCreation:
                 assert im.size == (1920, 1080)
 
     def test_creating_one_hundred_4K_images(self):
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 3840,
-                                  '--height', 2160,
-                                  '--count', 100,
-                                  '--image_format', 'png'])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            3840,
+            2160,
+            100,
+            'png',
+            0,
+            False
+        )
 
         images = glob(f'{str(self.tmpdir)}/*')
 

--- a/tests/functional/test_recordio.py
+++ b/tests/functional/test_recordio.py
@@ -14,9 +14,8 @@
 import pytest
 import re
 import os
-from click.testing import CliRunner
 from glob import glob
-from imagine.imagine import main
+from imagine.imagine import create_images, create_recordio
 from PIL import Image
 
 
@@ -25,7 +24,6 @@ class TestRecordIOCreation:
     def setup(self, tmpdir):
         self.tmpdir = tmpdir.mkdir('input_files')
         self.outdir = tmpdir.mkdir('output_files')
-        self.runner = CliRunner()
 
     def teardown_method(self):
         for image in glob(f'{str(self.tmpdir)}/*'):
@@ -37,18 +35,22 @@ class TestRecordIOCreation:
 
     def test_creating_recordio_from_100_jpgs(self):
         # Create sample images which will be used as a basis.
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 1920,
-                                  '--height', 1080,
-                                  '--count', 100,
-                                  '--image_format', 'jpg'])
-        self.runner.invoke(main, ['create-recordio',
-                                  '--source_path', str(self.tmpdir),
-                                  '--dest_path', str(self.outdir),
-                                  '--name', 'tmprecord_',
-                                  '--img_per_file', 100])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            1920,
+            1080,
+            100,
+            'jpg',
+            0,
+            False
+        )
+        create_recordio(
+            str(self.tmpdir),
+            str(self.outdir),
+            'tmprecord_',
+            100
+        )
 
         records = glob(f'{str(self.outdir)}/*')
 
@@ -59,18 +61,22 @@ class TestRecordIOCreation:
 
     def test_creating_recordio_from_100_pngs(self):
         # Create sample images which will be used as a basis.
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 1920,
-                                  '--height', 1080,
-                                  '--count', 100,
-                                  '--image_format', 'png'])
-        self.runner.invoke(main, ['create-recordio',
-                                  '--source_path', str(self.tmpdir),
-                                  '--dest_path', str(self.outdir),
-                                  '--name', 'tmprecord_',
-                                  '--img_per_file', 100])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            1920,
+            1080,
+            100,
+            'png',
+            0,
+            False
+        )
+        create_recordio(
+            str(self.tmpdir),
+            str(self.outdir),
+            'tmprecord_',
+            100
+        )
 
         records = glob(f'{str(self.outdir)}/*')
 
@@ -81,18 +87,22 @@ class TestRecordIOCreation:
 
     def test_creating_recordio_from_100_jpg_multiple_files(self):
         # Create sample images which will be used as a basis.
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 1920,
-                                  '--height', 1080,
-                                  '--count', 100,
-                                  '--image_format', 'jpg'])
-        self.runner.invoke(main, ['create-recordio',
-                                  '--source_path', str(self.tmpdir),
-                                  '--dest_path', str(self.outdir),
-                                  '--name', 'tmprecord_',
-                                  '--img_per_file', 10])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            1920,
+            1080,
+            100,
+            'jpg',
+            0,
+            False
+        )
+        create_recordio(
+            str(self.tmpdir),
+            str(self.outdir),
+            'tmprecord_',
+            10
+        )
 
         records = glob(f'{str(self.outdir)}/*')
 
@@ -103,18 +113,22 @@ class TestRecordIOCreation:
 
     def test_creating_recordio_from_100_pngs_multiple_files(self):
         # Create sample images which will be used as a basis.
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 1920,
-                                  '--height', 1080,
-                                  '--count', 100,
-                                  '--image_format', 'png'])
-        self.runner.invoke(main, ['create-recordio',
-                                  '--source_path', str(self.tmpdir),
-                                  '--dest_path', str(self.outdir),
-                                  '--name', 'tmprecord_',
-                                  '--img_per_file', 10])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            1920,
+            1080,
+            100,
+            'png',
+            0,
+            False
+        )
+        create_recordio(
+            str(self.tmpdir),
+            str(self.outdir),
+            'tmprecord_',
+            10
+        )
 
         records = glob(f'{str(self.outdir)}/*')
 

--- a/tests/functional/test_tfrecord.py
+++ b/tests/functional/test_tfrecord.py
@@ -14,9 +14,8 @@
 import pytest
 import re
 import os
-from click.testing import CliRunner
 from glob import glob
-from imagine.imagine import main
+from imagine.imagine import create_images, create_tfrecords
 from PIL import Image
 
 
@@ -25,7 +24,6 @@ class TestTFRecordCreation:
     def setup(self, tmpdir):
         self.tmpdir = tmpdir.mkdir('input_files')
         self.outdir = tmpdir.mkdir('output_files')
-        self.runner = CliRunner()
 
     def teardown_method(self):
         for image in glob(f'{str(self.tmpdir)}/*'):
@@ -37,18 +35,22 @@ class TestTFRecordCreation:
 
     def test_creating_tfrecord_from_100_jpgs(self):
         # Create sample images which will be used as a basis.
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 1920,
-                                  '--height', 1080,
-                                  '--count', 100,
-                                  '--image_format', 'jpg'])
-        self.runner.invoke(main, ['create-tfrecords',
-                                  '--source_path', str(self.tmpdir),
-                                  '--dest_path', str(self.outdir),
-                                  '--name', 'tmprecord_',
-                                  '--img_per_file', 100])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            1920,
+            1080,
+            100,
+            'jpg',
+            0,
+            False
+        )
+        create_tfrecords(
+            str(self.tmpdir),
+            str(self.outdir),
+            'tmprecord_',
+            100
+        )
 
         records = glob(f'{str(self.outdir)}/*')
 
@@ -57,18 +59,22 @@ class TestTFRecordCreation:
 
     def test_creating_tfrecord_from_100_pngs(self):
         # Create sample images which will be used as a basis.
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 1920,
-                                  '--height', 1080,
-                                  '--count', 100,
-                                  '--image_format', 'png'])
-        self.runner.invoke(main, ['create-tfrecords',
-                                  '--source_path', str(self.tmpdir),
-                                  '--dest_path', str(self.outdir),
-                                  '--name', 'tmprecord_',
-                                  '--img_per_file', 100])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            1920,
+            1080,
+            100,
+            'png',
+            0,
+            False
+        )
+        create_tfrecords(
+            str(self.tmpdir),
+            str(self.outdir),
+            'tmprecord_',
+            100
+        )
 
         records = glob(f'{str(self.outdir)}/*')
 
@@ -77,18 +83,22 @@ class TestTFRecordCreation:
 
     def test_creating_tfrecord_from_100_jpg_multiple_files(self):
         # Create sample images which will be used as a basis.
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 1920,
-                                  '--height', 1080,
-                                  '--count', 100,
-                                  '--image_format', 'jpg'])
-        self.runner.invoke(main, ['create-tfrecords',
-                                  '--source_path', str(self.tmpdir),
-                                  '--dest_path', str(self.outdir),
-                                  '--name', 'tmprecord_',
-                                  '--img_per_file', 10])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            1920,
+            1080,
+            100,
+            'jpg',
+            0,
+            False
+        )
+        create_tfrecords(
+            str(self.tmpdir),
+            str(self.outdir),
+            'tmprecord_',
+            10
+        )
 
         records = glob(f'{str(self.outdir)}/*')
 
@@ -98,18 +108,22 @@ class TestTFRecordCreation:
 
     def test_creating_tfrecord_from_100_pngs_multiple_files(self):
         # Create sample images which will be used as a basis.
-        self.runner.invoke(main, ['create-images',
-                                  '--path', str(self.tmpdir),
-                                  '--name', 'tmp_',
-                                  '--width', 1920,
-                                  '--height', 1080,
-                                  '--count', 100,
-                                  '--image_format', 'png'])
-        self.runner.invoke(main, ['create-tfrecords',
-                                  '--source_path', str(self.tmpdir),
-                                  '--dest_path', str(self.outdir),
-                                  '--name', 'tmprecord_',
-                                  '--img_per_file', 10])
+        create_images(
+            str(self.tmpdir),
+            'tmp_',
+            1920,
+            1080,
+            100,
+            'png',
+            0,
+            False
+        )
+        create_tfrecords(
+            str(self.tmpdir),
+            str(self.outdir),
+            'tmprecord_',
+            10
+        )
 
         records = glob(f'{str(self.outdir)}/*')
 


### PR DESCRIPTION
In an effort to make it easier to import the application as a library, the argument parsing should be replaced with the built-in argparser library to allow external code to call the various commands directly instead of forcing them to mock the click inputs.

Closes #7 

Signed-Off-By: Robert Clark <roclark@nvidia.com>