### PR TITLE
Make size flag a boolean

### DIFF
--- a/imagine/imagine.py
+++ b/imagine/imagine.py
@@ -101,7 +101,8 @@ def _parse_args() -> Namespace:
     standard.add_argument('--seed', help='The seed to use while generating '
                           'random image data', type=int, default=0)
     standard.add_argument('--size', help='Display the first image size and '
-                          'the directory size for the images')
+                          'the directory size for the images',
+                          action='store_true')
     return parser.parse_args()
 
 


### PR DESCRIPTION
The `--size` flag was being treated as a generic object which required any value to be passed to be considered `True`. This meant users had to specify `--size 1`, `--size True`, or similar in order to get the flag to work. Forcing the value to be `True` when passed and `False` otherwise is the original intended behavior.

Signed-Off-By: Robert Clark <roclark@nvidia.com>