### PR TITLE
Skip MXNet 1.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('VERSION', 'r') as f:
 
 extras = {
     'tfrecord': ['tensorflow >= 1.14.0,!=2.0.x,!=2.1.x,!=2.2.0'],
-    'mxnet': ['mxnet >= 1.6.0']
+    'mxnet': ['mxnet >= 1.6.0,!=1.8.0']
 }
 
 extras['all'] = [item for group in extras.values() for item in group]


### PR DESCRIPTION
MXNet 1.8.0 has an error loading the libopenblas.so.0 library and causes the package to fail immediately. This will be fixed in a future version of MXNet, but version 1.8.0 will likely always be broken and should be ignored. For more information, see https://github.com/apache/incubator-mxnet/pull/20086.

Signed-Off-By: Robert Clark <roclark@nvidia.com>