### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/pushtest.yml
+++ b/.github/workflows/pushtest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         operating-system: [ubuntu-latest, macOS-latest]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7]
         operating-system: [ubuntu-latest, macOS-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The images are generated using random numpy arrays and are then converted to the
 requested output format and saved to the specified location.
 
 ## Requirements
-  * Python 3.6 or greater
+  * Python 3.7 or greater
   * TensorFlow 2 or TensorFlow 1.14
   * MXNet
   * Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ iniconfig==1.1.1
 Keras-Preprocessing==1.1.2
 Markdown==3.2.2
 mxnet==1.6.0
-numpy==1.19.2
+numpy==1.19.3
 oauthlib==3.1.0
 opt-einsum==3.3.0
 packaging==20.4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description=long_description,
     packages=find_packages(include=['imagine'], exclude=['tests']),
     license='Apache 2.0',
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     entry_points={
         'console_scripts': ['imagine=imagine:_main']
     },


### PR DESCRIPTION
Python 3.6 has been EOL'ed and many dependencies have dropped support for it. As a result, Python 3.6 should be dropped from this repository to stay compatible with all dependencies.

Signed-Off-By: Robert Clark <roclark@nvidia.com>